### PR TITLE
Improve signature naming + add some comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Assuming you're using the typical `net/http` package, then the entire process is
 
 ```go
 func ExamplePage(response http.ResponseWriter, request *http.Request) {
-    gosteamauth.RedirectClient(response, request, gosteamauth.ConstructURL("http://localhost:8080/process"))
+    gosteamauth.RedirectClient(response, request, gosteamauth.BuildQueryString("http://localhost:8080/process"))
     return
 }
 ```

--- a/example/example.go
+++ b/example/example.go
@@ -30,7 +30,7 @@ func ExamplePage(resp http.ResponseWriter, req *http.Request) {
 	queryString := req.URL.Query()
 
 	if queryString.Get("login") == "true" {
-		gosteamauth.RedirectClient(resp, req, gosteamauth.ConstructURL("http://localhost:8080/process"))
+		gosteamauth.RedirectClient(resp, req, gosteamauth.BuildQueryString("http://localhost:8080/process"))
 		return
 	}
 


### PR DESCRIPTION
Does what it says on the tin.

- Changes` ConstructURL` -> `BuildQueryString` as that's more representative of what it does
- Build up the URL via `url.Parse` in `RedirectClient` instead of formatting them together
- Adds a bunch of comments to give an explanation as to the whys / hows.